### PR TITLE
QC changes - experimental 

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -33,6 +33,7 @@ rule all:
         extr="logs/extracted_complete.txt",
         subtest=DATESTRING['today']+"concatenated_ribosomal_proteins_db.fasta_2",
         dmnd="logs/blast_complete.txt",
+        trimm=DATESTRING['today']+".updateriboprotdedupe_trimmed.aln",
         report="report.html"
 
 
@@ -174,11 +175,23 @@ rule align:
      run:
          shell("(mafft --retree 3 --maxiterate 3 --thread {threads} {input} > {output}) 2>>log")
 
-rule create_tree:
+rule trim_alignment:
       input:
           DATESTRING['today']+".updateriboprotdedupe.aln"
       output:
-          DATESTRING['today']+".updateriboprotdedupe.aln.treefile"
+          DATESTRING['today']+".updateriboprotdedupe_trimmed.aln"
+      threads:
+          config['threads']
+      log:
+          log="logs/trimming.log"
+      run:
+          shell("(trimal -gt 0.2 -in {input} > {output})")          
+
+rule create_tree:
+      input:
+          DATESTRING['today']+".updateriboprotdedupe_trimmed.aln"
+      output:
+          DATESTRING['today']+".updateriboprotdedupe_trimmed.aln.treefile"
       params:
           tree_type = config['tree_type']['options'],
           protein_dna = config['protein_dna']['options']
@@ -197,7 +210,7 @@ rule create_tree:
 
 rule report:
       input:
-          DATESTRING['today']+".updateriboprotdedupe.aln.treefile"
+          DATESTRING['today']+".updateriboprotdedupe_trimmed.aln.treefile"
       output:
           "report.html"
       run:

--- a/Snakefile
+++ b/Snakefile
@@ -33,7 +33,8 @@ rule all:
         extr="logs/extracted_complete.txt",
         subtest=DATESTRING['today']+"concatenated_ribosomal_proteins_db.fasta_2",
         dmnd="logs/blast_complete.txt",
-        trimm=DATESTRING['today']+".updateriboprotdedupe_trimmed.aln",
+        trimm="logs/trimming.log",
+        tre="logs/create_tree.txt",
         report="report.html"
 
 
@@ -191,14 +192,14 @@ rule create_tree:
       input:
           DATESTRING['today']+".updateriboprotdedupe_trimmed.aln"
       output:
-          DATESTRING['today']+".updateriboprotdedupe_trimmed.aln.treefile"
+          DATESTRING['today']+".updateriboprotdedupe_trimmed.aln.log"
       params:
           tree_type = config['tree_type']['options'],
           protein_dna = config['protein_dna']['options']
       threads:
           config['threads']
       log:
-          "logs/create_tree.log"
+          "logs/create_tree.txt"
       run:
           if params.tree_type == 'iqtree':
                if params.protein_dna == 'dna':
@@ -210,7 +211,7 @@ rule create_tree:
 
 rule report:
       input:
-          DATESTRING['today']+".updateriboprotdedupe_trimmed.aln.treefile"
+          DATESTRING['today']+".updateriboprotdedupe_trimmed.aln.log"
       output:
           "report.html"
       run:

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -33,6 +33,8 @@ rule all:
         extr="logs/extracted_complete.txt",
         subtest=DATESTRING['today']+"concatenated_ribosomal_proteins_db.fasta_2",
         dmnd="logs/blast_complete.txt",
+        trimm="logs/trimming.log",
+        tre="logs/create_tree.txt",
         report="report.html"
 
 
@@ -174,18 +176,30 @@ rule align:
      run:
          shell("(mafft --retree 3 --maxiterate 3 --thread {threads} {input} > {output}) 2>>log")
 
-rule create_tree:
+rule trim_alignment:
       input:
           DATESTRING['today']+".updateriboprotdedupe.aln"
       output:
-          DATESTRING['today']+".updateriboprotdedupe.aln.treefile"
+          DATESTRING['today']+".updateriboprotdedupe_trimmed.aln"
+      threads:
+          config['threads']
+      log:
+          log="logs/trimming.log"
+      run:
+          shell("(trimal -gt 0.2 -in {input} > {output})")          
+
+rule create_tree:
+      input:
+          DATESTRING['today']+".updateriboprotdedupe_trimmed.aln"
+      output:
+          DATESTRING['today']+".updateriboprotdedupe_trimmed.aln.log"
       params:
           tree_type = config['tree_type']['options'],
           protein_dna = config['protein_dna']['options']
       threads:
           config['threads']
       log:
-          "logs/create_tree.log"
+          "logs/create_tree.txt"
       run:
           if params.tree_type == 'iqtree':
                if params.protein_dna == 'dna':
@@ -197,7 +211,7 @@ rule create_tree:
 
 rule report:
       input:
-          DATESTRING['today']+".updateriboprotdedupe.aln.treefile"
+          DATESTRING['today']+".updateriboprotdedupe_trimmed.aln.log"
       output:
           "report.html"
       run:

--- a/workflow/scripts/ribo_concat_diamond.py
+++ b/workflow/scripts/ribo_concat_diamond.py
@@ -22,7 +22,6 @@ def collect_expected_seqlengths(inf_ribos, prot_dna):
             dicty[inf_id] = int(seqlen)
     print(dicty)
     return dicty
-    
 
 def concatenate_diamond_matches(infile, prot_dna):
     import collections
@@ -34,6 +33,14 @@ def concatenate_diamond_matches(infile, prot_dna):
     inf_two = open('atccs.txt', 'r')
     inf_ribos = [lin.rstrip() for lin in inf_two]
     dicty = collect_expected_seqlengths(inf_ribos, prot_dna)
+    if prot_dna == "protein":
+        #QC outlier cutoffs per protein calculated from rounded up differences of median lengths of all uniprot curated ribosomal proteins plus or minus 1.5 * IQR  
+        dict_differences = {'rplB':16, 'rplC':72, 'rplD': 20, 'rplE': 15, 'rplF': 10, 'rplN': 4, 'rplO': 26, 'rplP': 15, 'rplR': 8, 'rplV': 32, 'rplX': 33, 'rpsC': 71, 'rpsH': 4, 'rpsJ': 19, 'rpsQ': 11, 'rpsS': 17}
+    elif prot_dna == "dna":
+        nuc_dict = {k: v * 3 for k, v in dicty.items()}
+        dicty = nuc_dict
+    else:
+        print("problem with the input format")
     ribo_names_field = 1 #ribo_names_field
     print("ribo_names_field", ribo_names_field)
     d = collections.defaultdict(dict)
@@ -64,7 +71,7 @@ def concatenate_diamond_matches(infile, prot_dna):
         for ribo in ribosomal_proteins:
             if rib == ribo:
                 #check for exact match
-                if  len(newseq) - 20 < dicty[rib] < len(newseq) + 20:   
+                if  (len(newseq) - dict_differences[rib]) < dicty[rib] < (len(newseq) + dict_differences[rib]):   
                     try:
                         d[newid][ribo].append(newseq)
                     except:


### PR DESCRIPTION
1. Altered Snakefile to include a trimming rule with trimal.  Parameters were chosen from the literature Du <i>et al</i>. 2019 BMC Evol.Biol 19:203.
2. Altered the concatenation script to alter the QC cut off (previously 20 aa shorter and 20 aa longer than the reference ribosomal protein of that type).  Alteration is considering specific length differences of each ribosomal protein based on an investigation of the IQR of lengths from Uniprot curated ribosomal proteins (~ 1000 of each).
- Lisa
