### PR TITLE
adding fix to extract ribosomal seqs from some other filetypes

### DIFF
--- a/workflow/scripts/extract_ribo_seqs_from_gbk.py
+++ b/workflow/scripts/extract_ribo_seqs_from_gbk.py
@@ -2,6 +2,7 @@
 
 from Bio import SeqIO
 from Bio.Seq import Seq
+import re
 from Bio.SeqRecord import SeqRecord
 from Bio.SeqFeature import SeqFeature
 import sys
@@ -31,7 +32,8 @@ for rec in records:
     for feature in rec.features:
         if feature.type == "CDS":
           try:
-            if 'ribosomal protein' in ''.join(feature.qualifiers['product']):
+            product = ''.join(feature.qualifiers['product'])
+            if re.search(r'\bribosomal( subunit)? protein\b', product, re.IGNORECASE):
                 print(feature.qualifiers['locus_tag'], feature.qualifiers['product'])
                 print("ribo_count is", ribo_count, "seen_before", seen_before)
                 if ribo_count > 16:


### PR DESCRIPTION
Original extraction script was looking for 'ribosomal protein' in the feature product annotation, however, I uncovered that a lot of genbank files are now using the term 'ribosomal subunit protein' in the feature product annotation.
Therefore, here is a fix to gather both terms.
Currently in an example file where 'ribosomal subunit protein' is used as a term, this would not be found by the extract_ribo_seqs_from_gbk.py script.  This would cause a BLAST subworkflow to be run which is not as fast and uses more resources.  Therefore this fix will be more efficient and faster for files containing 'ribosomal subunit protein' as a term in the product line.